### PR TITLE
[hotfix] cmd/faucet: unmarshalling errors: validators field missing

### DIFF
--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -310,6 +310,10 @@ func (f *faucet) apiHandler(conn *websocket.Conn) {
 
 		// If stats retrieval failed, wait a bit and retry
 		if err != nil {
+
+			// @NOTE (rgeraldes) - Unmarshalling errors are probably due to this return message:
+			// https://github.com/kowala-tech/kcoin/blob/dev/internal/kcoinapi/api.go#L698
+			// new fields in the header (required fields) must be added to that return msg.
 			if err = sendError(conn, errors.New("Faucet offline: "+err.Error())); err != nil {
 				log.Warn("Failed to send faucet error to client", "err", err)
 				return

--- a/internal/kcoinapi/api.go
+++ b/internal/kcoinapi/api.go
@@ -709,6 +709,8 @@ func (s *PublicBlockChainAPI) rpcOutputBlock(b *types.Block, inclTx bool, fullTx
 		"timestamp":        (*hexutil.Big)(head.Time),
 		"transactionsRoot": head.TxHash,
 		"receiptsRoot":     head.ReceiptHash,
+		"validators":       head.ValidatorsHash,
+		"lastCommit":       head.LastCommitHash,
 	}
 
 	if inclTx {


### PR DESCRIPTION
Unmarshalling errors like this one "faucet offline: validators field missing" are due to this return message: https://github.com/kowala-tech/kcoin/blob/dev/internal/kcoinapi/api.go#L698
New fields in the block header (required fields) must be added to that return msg otherwise the faucet will not work!

Test: 

Genesis Validator:

./kcoin --config /Users/ricardogeraldes/Code/src/github.com/kowala-tech/kcoin/internal/assets/sample-kowala.toml init /Users/ricardogeraldes/Code/src/github.com/kowala-tech/kcoin/release/testnet_genesis.json
cp /Users/ricardogeraldes/Code/src/github.com/kowala-tech/kcoin/internal/assets/UTC--2018-01-16T16-31-38.006625000Z--d6e579085c82329c89fca7a9f012be59028ed53f /Users/ricardogeraldes/Code/src/github.com/kowala-tech/kcoin/build/bin/.kowala/keystore 
./kcoin --config /Users/ricardogeraldes/Code/src/github.com/kowala-tech/kcoin/internal/assets/sample-kowala.toml --validate --coinbase 0xd6e579085c82329c89fca7a9f012be59028ed53f --unlock 0xd6e579085c82329c89fca7a9f012be59028ed53f console

Faucet:

./faucet --genesis /Users/ricardogeraldes/Code/src/github.com/kowala-tech/kcoin/release/testnet_genesis.json --bootnodes "enode://7d75353d0ee2d94a072ed280fb705e930001c5002c27e91170f8c115b2b9a272806070f23826f5debfff55aca979c2fc334081e679ef01482a800a0395c745a3@127.0.0.1:30303" --account.json /Users/ricardogeraldes/Code/src/github.com/kowala-tech/kcoin/internal/assets/UTC--2018-01-16T16-31-38.006625000Z--d6e579085c82329c89fca7a9f012be59028ed53f --account.pass /Users/ricardogeraldes/Code/src/github.com/kowala-tech/kcoin/internal/assets/password.txt --kcoinport 30004 --network 3680923 --noauth