### PR TITLE
Fixes import circles running godog tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,4 +184,4 @@ ifndef GODOG_BIN
 	@echo "Installing godog..."
 	@go get github.com/DATA-DOG/godog/cmd/godog
 endif
-	@godog
+	@cd tests && godog ../features

--- a/cluster/docker_images.go
+++ b/cluster/docker_images.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path"
 	"sync"
 	"time"
 )
@@ -58,7 +59,7 @@ func (builder *DockerBuilder) Wait() []error {
 }
 
 func (builder *DockerBuilder) build(tag, dockerfile string) error {
-	cmd := exec.Command("docker", "build", "-t", tag, "-f", dockerfile, ".")
+	cmd := exec.Command("docker", "build", "-t", tag, "-f", path.Join(rootPath, dockerfile), rootPath)
 
 	env := os.Environ()
 	for _, e := range builder.env {

--- a/cluster/utils.go
+++ b/cluster/utils.go
@@ -2,6 +2,8 @@ package cluster
 
 import "encoding/hex"
 
+const rootPath = ".."
+
 func randStringBytes(n int) string {
 	b := make([]byte, n/2)
 

--- a/tests/godogs_test.go
+++ b/tests/godogs_test.go
@@ -1,4 +1,4 @@
-package kowala
+package tests
 
 import (
 	"time"


### PR DESCRIPTION
Godogs runs from the root, where a very generic `interfaces.go` lives. If e2e at some point load some utility packages like `kcoinclient`, it creates a circular dependency.
This change makes godog run from `/tests` instead of the root.