### PR TITLE
Feature/e2e fast accounts

### DIFF
--- a/tests/features/accounts.go
+++ b/tests/features/accounts.go
@@ -60,6 +60,7 @@ func (ctx *Context) IHaveTheFollowingAccounts(accountsDataTable *gherkin.DataTab
 
 		ctx.accounts[accountData.AccountName] = account
 
+		// TODO: Use genesis validator key to send a transaction using the client instead of Exec
 		_, err = ctx.cluster.Exec(ctx.genesisValidatorName,
 			fmt.Sprintf(
 				`eth.sendTransaction({

--- a/tests/features/accounts.go
+++ b/tests/features/accounts.go
@@ -60,7 +60,6 @@ func (ctx *Context) IHaveTheFollowingAccounts(accountsDataTable *gherkin.DataTab
 
 		ctx.accounts[accountData.AccountName] = account
 
-		// TODO: Use genesis validator key to send a transaction using the client instead of Exec
 		_, err = ctx.cluster.Exec(ctx.genesisValidatorName,
 			fmt.Sprintf(
 				`eth.sendTransaction({

--- a/tests/features/context.go
+++ b/tests/features/context.go
@@ -2,6 +2,7 @@ package features
 
 import (
 	"io/ioutil"
+	"math/big"
 
 	"github.com/kowala-tech/kcoin/accounts"
 	"github.com/kowala-tech/kcoin/accounts/keystore"
@@ -14,6 +15,7 @@ type Context struct {
 	cluster              cluster.Cluster
 	client               *kcoinclient.Client
 	genesisValidatorName string
+	chainID              *big.Int
 
 	accountsStorage *keystore.KeyStore
 
@@ -23,7 +25,7 @@ type Context struct {
 	lastTxErr error
 }
 
-func NewTestContext(k8sCluster cluster.Cluster, genesisValidatorName string, client *kcoinclient.Client) *Context {
+func NewTestContext(k8sCluster cluster.Cluster, genesisValidatorName string, client *kcoinclient.Client, chainID *big.Int) *Context {
 	tmpdir, _ := ioutil.TempDir("", "eth-keystore-test")
 	accountsStorage := keystore.NewKeyStore(tmpdir, 2, 1)
 

--- a/tests/features/context.go
+++ b/tests/features/context.go
@@ -1,7 +1,12 @@
 package features
 
 import (
+	"io/ioutil"
+
+	"github.com/kowala-tech/kcoin/accounts"
+	"github.com/kowala-tech/kcoin/accounts/keystore"
 	"github.com/kowala-tech/kcoin/cluster"
+	"github.com/kowala-tech/kcoin/core/types"
 	"github.com/kowala-tech/kcoin/kcoinclient"
 )
 
@@ -10,19 +15,25 @@ type Context struct {
 	client               *kcoinclient.Client
 	genesisValidatorName string
 
-	accountsNodeNames map[string]string
-	accountsCoinbase  map[string]string
+	accountsStorage *keystore.KeyStore
 
-	lastTxStdout string
+	accounts map[string]accounts.Account
+
+	lastTx    *types.Transaction
+	lastTxErr error
 }
 
 func NewTestContext(k8sCluster cluster.Cluster, genesisValidatorName string, client *kcoinclient.Client) *Context {
+	tmpdir, _ := ioutil.TempDir("", "eth-keystore-test")
+	accountsStorage := keystore.NewKeyStore(tmpdir, 2, 1)
+
 	return &Context{
 		cluster:              k8sCluster,
 		client:               client,
 		genesisValidatorName: genesisValidatorName,
 
-		accountsNodeNames: make(map[string]string),
-		accountsCoinbase:  make(map[string]string),
+		accountsStorage: accountsStorage,
+
+		accounts: make(map[string]accounts.Account),
 	}
 }

--- a/tests/features/transactions.go
+++ b/tests/features/transactions.go
@@ -3,7 +3,6 @@ package features
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"regexp"
 	"time"
 
@@ -55,7 +54,6 @@ func (ctx *Context) isTransactionInBlockchain(tx *types.Transaction) (bool, erro
 }
 
 func (ctx *Context) sendFunds(from, to accounts.Account, kcoin int64) (*types.Transaction, error) {
-	chainID := big.NewInt(519374298533)
 	nonce, err := ctx.client.NonceAt(context.Background(), from.Address, nil)
 	if err != nil {
 		return nil, err
@@ -78,7 +76,7 @@ func (ctx *Context) sendFunds(from, to accounts.Account, kcoin int64) (*types.Tr
 
 	tx := types.NewTransaction(nonce, to.Address, toWei(kcoin), gas, gp, nil)
 
-	tx, err = ctx.accountsStorage.SignTxWithPassphrase(from, "test", tx, chainID)
+	tx, err = ctx.accountsStorage.SignTxWithPassphrase(from, "test", tx, ctx.chainID)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/features/transactions.go
+++ b/tests/features/transactions.go
@@ -3,15 +3,12 @@ package features
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"time"
 
 	kowala "github.com/kowala-tech/kcoin"
 	"github.com/kowala-tech/kcoin/accounts"
 	"github.com/kowala-tech/kcoin/core/types"
 )
-
-var txRegexp = regexp.MustCompile(`0x[0-9a-f]{64}`)
 
 func (ctx *Context) ITransferKUSD(kcoin int64, from, to string) error {
 

--- a/tests/godogs_test.go
+++ b/tests/godogs_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"math/big"
 	"time"
 
 	"github.com/kowala-tech/kcoin/kcoinclient"
@@ -14,6 +15,7 @@ var (
 	k8sCluster           cluster.Cluster
 	genesisValidatorName string
 	client               *kcoinclient.Client
+	chainID              = big.NewInt(519374298533)
 )
 
 func FeatureContext(s *godog.Suite) {
@@ -24,7 +26,7 @@ func FeatureContext(s *godog.Suite) {
 	}
 	s.AfterSuite(cleanupCluster)
 
-	context := features.NewTestContext(k8sCluster, genesisValidatorName, client)
+	context := features.NewTestContext(k8sCluster, genesisValidatorName, client, chainID)
 	s.Step(`^I have the following accounts:$`, context.IHaveTheFollowingAccounts)
 	s.Step(`^I transfer (\d+) kcoins? from (\w+) to (\w+)$`, context.ITransferKUSD)
 	s.Step(`^I try to transfer (\d+) kcoins? from (\w+) to (\w+)$`, context.ITryTransferKUSD)
@@ -48,7 +50,7 @@ func prepareCluster() {
 
 	k8sCluster.Cleanup() // Just in case the previous run didn't finish gracefully
 
-	if err := k8sCluster.Initialize("519374298533"); err != nil {
+	if err := k8sCluster.Initialize(chainID.String()); err != nil {
 		panic(err)
 	}
 	if err := k8sCluster.RunBootnode(); err != nil {


### PR DESCRIPTION
Close #227 

Creating new accounts in the e2e tests doesn't instantiate a new instance for each account anymore. Instead, we have a key storage and create accounts there. With it, we can now send transactions using the client instead of console commands.