### PR TITLE
Feature/e2e better genesis use

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kowala-tech/kcoin/common"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -69,7 +70,7 @@ func (client *cluster) Cleanup() error {
 	return client.waitForNoServices()
 }
 
-func (client *cluster) Initialize(networkID string) error {
+func (client *cluster) Initialize(networkID string, seedAccount common.Address) error {
 	log.Println("Initializing cluster")
 	client.NetworkID = networkID
 
@@ -93,7 +94,7 @@ func (client *cluster) Initialize(networkID string) error {
 	if err := client.addKeysPassword(); err != nil {
 		return err
 	}
-	if err := client.generateGenesis(); err != nil {
+	if err := client.generateGenesis(seedAccount); err != nil {
 		return err
 	}
 	if errs := builder.Wait(); len(errs) > 0 {

--- a/cluster/genesis.go
+++ b/cluster/genesis.go
@@ -6,12 +6,13 @@ import (
 
 	"encoding/json"
 
+	"github.com/kowala-tech/kcoin/common"
 	"github.com/kowala-tech/kcoin/kcoin/genesis"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (client *cluster) generateGenesis() error {
+func (client *cluster) generateGenesis(seedAccount common.Address) error {
 	log.Println("Generating and storing genesis configmap")
 	configMaps := client.Clientset.CoreV1().ConfigMaps(Namespace)
 
@@ -32,6 +33,10 @@ func (client *cluster) generateGenesis() error {
 			PrefundedAccounts: []genesis.PrefundedAccount{
 				{
 					AccountAddress: "0xd6e579085c82329c89fca7a9f012be59028ed53f",
+					Balance:        "0x200000000000000000000000000000000000000000000000000000000000000",
+				},
+				{
+					AccountAddress: seedAccount.Hex(),
 					Balance:        "0x200000000000000000000000000000000000000000000000000000000000000",
 				},
 				{

--- a/cluster/interfaces.go
+++ b/cluster/interfaces.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"math/big"
 
+	"github.com/kowala-tech/kcoin/common"
 	"github.com/kowala-tech/kcoin/kcoinclient"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -41,7 +42,7 @@ type Cluster interface {
 
 	// Initialize prepares a new cluster to be ready to start. It saves the networkID for future pods
 	// to use it, generates a genesis and stores initial keys in the cluster.
-	Initialize(networkID string) error
+	Initialize(networkID string, seedAccount common.Address) error
 
 	// Cleanup deletes all pods, leaving the kluster in a fresh state
 	Cleanup() error

--- a/tests/features/accounts.go
+++ b/tests/features/accounts.go
@@ -53,14 +53,17 @@ func (ctx *Context) IHaveTheFollowingAccounts(accountsDataTable *gherkin.DataTab
 
 	// Create an archive node for each account and send them funds
 	for _, accountData := range accountsData {
-		account, err := ctx.accountsStorage.NewAccount("test")
+		if _, ok := ctx.accounts[accountData.AccountName]; ok {
+			return fmt.Errorf("an account with this name already exists: %s", accountData.AccountName)
+		}
+		account, err := ctx.AccountsStorage.NewAccount("test")
 		if err != nil {
 			return err
 		}
 
 		ctx.accounts[accountData.AccountName] = account
 
-		_, err = ctx.cluster.Exec(ctx.genesisValidatorName,
+		_, err = ctx.cluster.Exec("genesis-validator",
 			fmt.Sprintf(
 				`eth.sendTransaction({
 				from:eth.coinbase,

--- a/tests/features/cluster.go
+++ b/tests/features/cluster.go
@@ -1,0 +1,58 @@
+package features
+
+import (
+	"time"
+
+	"github.com/kowala-tech/kcoin/cluster"
+)
+
+func (ctx *Context) IsClusterReady() bool {
+	return ctx.cluster != nil
+}
+
+func (ctx *Context) PrepareCluster() error {
+	backend := cluster.NewMinikubeCluster("testing")
+	if !backend.Exists() {
+		if err := backend.Create(); err != nil {
+			return err
+		}
+	}
+	ctx.cluster = cluster.NewCluster(backend)
+
+	if err := ctx.cluster.Connect(); err != nil {
+		return err
+	}
+
+	ctx.cluster.Cleanup() // Just in case the previous run didn't finish gracefully
+
+	if err := ctx.cluster.Initialize(ctx.chainID.String()); err != nil {
+		return err
+	}
+	if err := ctx.cluster.RunBootnode(); err != nil {
+		return err
+	}
+	_, err := ctx.cluster.RunGenesisValidator()
+	if err := err; err != nil {
+		return err
+	}
+	if err := ctx.cluster.TriggerGenesisValidation(); err != nil {
+		return err
+	}
+	_, err = ctx.cluster.RunRpcNode()
+	if err != nil {
+		return err
+	}
+
+	newClient, err := ctx.cluster.RpcClient()
+	if err != nil {
+		return err
+	}
+	ctx.client = newClient
+
+	time.Sleep(3 * time.Second) // let the genesis validator generate some blocks
+	return nil
+}
+
+func (ctx *Context) DeleteCluster() error {
+	return ctx.cluster.Cleanup()
+}

--- a/tests/features/context.go
+++ b/tests/features/context.go
@@ -12,12 +12,11 @@ import (
 )
 
 type Context struct {
-	cluster              cluster.Cluster
-	client               *kcoinclient.Client
-	genesisValidatorName string
-	chainID              *big.Int
+	AccountsStorage *keystore.KeyStore
 
-	accountsStorage *keystore.KeyStore
+	cluster cluster.Cluster
+	client  *kcoinclient.Client
+	chainID *big.Int
 
 	accounts map[string]accounts.Account
 
@@ -25,17 +24,18 @@ type Context struct {
 	lastTxErr error
 }
 
-func NewTestContext(k8sCluster cluster.Cluster, genesisValidatorName string, client *kcoinclient.Client, chainID *big.Int) *Context {
+func NewTestContext(chainID *big.Int) *Context {
 	tmpdir, _ := ioutil.TempDir("", "eth-keystore-test")
 	accountsStorage := keystore.NewKeyStore(tmpdir, 2, 1)
 
 	return &Context{
-		cluster:              k8sCluster,
-		client:               client,
-		genesisValidatorName: genesisValidatorName,
-
-		accountsStorage: accountsStorage,
+		AccountsStorage: accountsStorage,
+		chainID:         chainID,
 
 		accounts: make(map[string]accounts.Account),
 	}
+}
+
+func (ctx *Context) Reset() {
+	ctx.accounts = make(map[string]accounts.Account)
 }

--- a/tests/features/context.go
+++ b/tests/features/context.go
@@ -18,7 +18,8 @@ type Context struct {
 	client  *kcoinclient.Client
 	chainID *big.Int
 
-	accounts map[string]accounts.Account
+	seederAccount accounts.Account
+	accounts      map[string]accounts.Account
 
 	lastTx    *types.Transaction
 	lastTxErr error

--- a/tests/features/transactions.go
+++ b/tests/features/transactions.go
@@ -73,7 +73,7 @@ func (ctx *Context) sendFunds(from, to accounts.Account, kcoin int64) (*types.Tr
 
 	tx := types.NewTransaction(nonce, to.Address, toWei(kcoin), gas, gp, nil)
 
-	tx, err = ctx.accountsStorage.SignTxWithPassphrase(from, "test", tx, ctx.chainID)
+	tx, err = ctx.AccountsStorage.SignTxWithPassphrase(from, "test", tx, ctx.chainID)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/features/transactions.go
+++ b/tests/features/transactions.go
@@ -73,7 +73,7 @@ func (ctx *Context) sendFunds(from, to accounts.Account, kcoin int64) (*types.Tr
 
 	tx := types.NewTransaction(nonce, to.Address, toWei(kcoin), gas, gp, nil)
 
-	tx, err = ctx.AccountsStorage.SignTxWithPassphrase(from, "test", tx, ctx.chainID)
+	tx, err = ctx.AccountsStorage.SignTx(from, tx, ctx.chainID)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/features/utils.go
+++ b/tests/features/utils.go
@@ -6,13 +6,11 @@ import (
 	"time"
 
 	"github.com/kowala-tech/kcoin/cluster"
+	"github.com/kowala-tech/kcoin/params"
 )
 
-var kcoinWei = big.NewInt(1000000000000000000)
-
 func toWei(kcoin int64) *big.Int {
-	res := big.NewInt(kcoin)
-	return res.Mul(res, kcoinWei)
+	return new(big.Int).Mul(big.NewInt(kcoin), big.NewInt(params.Ether))
 }
 
 func waitFor(errorMessage string, tickTime, timeout time.Duration, condition func() bool) error {

--- a/tests/godogs_test.go
+++ b/tests/godogs_test.go
@@ -2,82 +2,38 @@ package tests
 
 import (
 	"math/big"
-	"time"
-
-	"github.com/kowala-tech/kcoin/kcoinclient"
 
 	"github.com/DATA-DOG/godog"
-	"github.com/kowala-tech/kcoin/cluster"
 	"github.com/kowala-tech/kcoin/tests/features"
 )
 
 var (
-	k8sCluster           cluster.Cluster
-	genesisValidatorName string
-	client               *kcoinclient.Client
-	chainID              = big.NewInt(519374298533)
+	chainID = big.NewInt(519374298533)
 )
 
 func FeatureContext(s *godog.Suite) {
+	context := features.NewTestContext(chainID)
+
 	// Use this approach instead of `BeforeSuite` because we need it right away,
 	//  the `BeforeSuite` runs after executing the current function
-	if k8sCluster == nil {
-		prepareCluster()
+	if !context.IsClusterReady() {
+		if err := context.PrepareCluster(); err != nil {
+			panic(err)
+		}
 	}
-	s.AfterSuite(cleanupCluster)
+	s.AfterSuite(func() {
+		if err := context.DeleteCluster(); err != nil {
+			panic(err)
+		}
+	})
 
-	context := features.NewTestContext(k8sCluster, genesisValidatorName, client, chainID)
+	s.BeforeScenario(func(interface{}) {
+		context.Reset()
+	})
 	s.Step(`^I have the following accounts:$`, context.IHaveTheFollowingAccounts)
 	s.Step(`^I transfer (\d+) kcoins? from (\w+) to (\w+)$`, context.ITransferKUSD)
 	s.Step(`^I try to transfer (\d+) kcoins? from (\w+) to (\w+)$`, context.ITryTransferKUSD)
 	s.Step(`^the balance of (\w+) should be (\d+) kcoins?$`, context.TheBalanceIsExactly)
 	s.Step(`^the balance of (\w+) should be around (\d+) kcoins?$`, context.TheBalanceIsAround)
 	s.Step(`^the transaction should fail$`, context.LastTransactionFailed)
-}
-
-func prepareCluster() {
-	backend := cluster.NewMinikubeCluster("testing")
-	if !backend.Exists() {
-		if err := backend.Create(); err != nil {
-			panic(err)
-		}
-	}
-	k8sCluster = cluster.NewCluster(backend)
-
-	if err := k8sCluster.Connect(); err != nil {
-		panic(err)
-	}
-
-	k8sCluster.Cleanup() // Just in case the previous run didn't finish gracefully
-
-	if err := k8sCluster.Initialize(chainID.String()); err != nil {
-		panic(err)
-	}
-	if err := k8sCluster.RunBootnode(); err != nil {
-		panic(err)
-	}
-	name, err := k8sCluster.RunGenesisValidator()
-	if err := err; err != nil {
-		panic(err)
-	}
-	genesisValidatorName = name
-	if err := k8sCluster.TriggerGenesisValidation(); err != nil {
-		panic(err)
-	}
-	name, err = k8sCluster.RunRpcNode()
-	if err != nil {
-		panic(err)
-	}
-
-	newClient, err := k8sCluster.RpcClient()
-	if err != nil {
-		panic(err)
-	}
-	client = newClient
-
-	time.Sleep(3 * time.Second) // let the genesis validator generate some blocks
-}
-
-func cleanupCluster() {
-	k8sCluster.Cleanup()
 }


### PR DESCRIPTION
Close #234 

Changes how we add funds to new accounts in the e2e tests.
The cluster now it's initialised with an arbitratry account prefunded from Genesis. This account (called seed account) is the one used now to fund new accounts.
