### PR TITLE
Save e2e docker containers logs to files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /build/_workspace/
 /build/bin/
 /kcoin*.zip
+/tests/logs
 
 # dashboard
 /dashboard/assets/node_modules

--- a/tests/features/cluster.go
+++ b/tests/features/cluster.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -26,7 +27,12 @@ func (ctx *Context) DeleteCluster() error {
 }
 
 func (ctx *Context) PrepareCluster() error {
-	nodeRunner, err := cluster.NewDockerNodeRunner()
+	logsDir := "./logs"
+	os.RemoveAll(logsDir)
+	if err := os.Mkdir(logsDir, 0700); err != nil {
+		return err
+	}
+	nodeRunner, err := cluster.NewDockerNodeRunner(logsDir)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When we run nodes in the e2e tests, it'll stream all logs to `/tests/logs`.

The filenames have the following format: `N-NODE_NAME.log`, where N is an sequence and the NODE_NAME is the name of the node running.

The logs are cleaned up every time it runs