### PR TITLE
Runs WaitFor condition right away

### DIFF
--- a/common/wait_for.go
+++ b/common/wait_for.go
@@ -6,6 +6,9 @@ import (
 )
 
 func WaitFor(errorMessage string, tickTime, timeout time.Duration, condition func() bool) error {
+	if condition() {
+		return nil
+	}
 	timeoutTime := time.After(timeout)
 	tick := time.Tick(tickTime)
 


### PR DESCRIPTION
Runs the condition of `waitFor` right away, in case it's satisfied when it first runs and it doesn't need to wait for one tick.