### PR TITLE
Fix error waiting for transactions

### DIFF
--- a/tests/features/transactions.go
+++ b/tests/features/transactions.go
@@ -48,7 +48,10 @@ func (ctx *Context) LastTransactionFailed() error {
 
 func (ctx *Context) isTransactionInBlockchain(tx *types.Transaction) (bool, error) {
 	receipt, err := ctx.client.TransactionReceipt(context.Background(), tx.Hash())
-	return receipt.Status == types.ReceiptStatusSuccessful, err
+	if err != nil {
+		return false, err
+	}
+	return receipt.Status == types.ReceiptStatusSuccessful, nil
 }
 
 func (ctx *Context) sendFunds(from, to accounts.Account, kcoin int64) (*types.Transaction, error) {


### PR DESCRIPTION
When a transaction is not found, this function was failing because `receipt` is `nil`.