### PR TITLE
Account creation Docker commands

### DIFF
--- a/release/kcoin.sh
+++ b/release/kcoin.sh
@@ -1,15 +1,47 @@
 #!/bin/sh
 set -e
 
+TESTNET=false;
+NEW_ACC=false;
+NEW_ACC_PASS="";
+
+command="";
+
+while [[ $# -gt 0 ]] ;
+do
+    opt="$1";
+    shift;        
+
+    case "$opt" in
+	  "--testnet")
+		TESTNET=true
+		command="$command$opt " # make sure this passed to the binary
+		;;
+	  "--new-account")
+		NEW_ACC=true
+		;;
+	  "--new-account-password="*)
+		NEW_ACC_PASS="${opt#*=}"
+		;;
+	  *)
+		command="$command$opt " # make sure this passed to the binary
+		;;
+	esac
+done
+
 cd /kcoin
 
-case "$@" in 
-  *"--testnet"*)
-    ./kcoin init /kcoin/testnet_genesis.json
-    ;;
-  *)
-    ./kcoin init /kcoin/genesis.json
-    ;;
+case $TESTNET in
+	(true)  ./kcoin init /kcoin/testnet_genesis.json;;
+	(false) ./kcoin init /kcoin/genesis.json;;
+esac
+
+case $NEW_ACC in
+	(true)
+		echo "$NEW_ACC_PASS" > .password
+		./kcoin account new --password .password
+		rm .password
+		;;
 esac
 
 ./control --ipc /root/.kcoin/kcoin.ipc &
@@ -19,4 +51,5 @@ if [ $status -ne 0 ]; then
   exit $status
 fi
 
-./kcoin "$@"
+
+./kcoin $command


### PR DESCRIPTION
This reintroduces the concept of generating accounts for testing purposes, only it does so explicitly using CLI arguments passed to the shell script in the Docker image. 

It's not possible to run:

```
docker run --rm -it kcoindev [--new-account [--new-account-password=<password>]] [other flags] 
```

The account still needs to be unlocked, but at least it gets created.