### PR TITLE
Removed old testnet and Gitter links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](http://ci.kowala.io/api/badges/kowala-tech/kcoin/status.svg)](http://ci.kowala.io/kowala-tech/kcoin) [![Public testnet](https://img.shields.io/badge/public-testnet-981071.svg)](http://testnet.kowala.io)
+[![Build Status](http://ci.kowala.io/api/badges/kowala-tech/kcoin/status.svg)](http://ci.kowala.io/kowala-tech/kcoin) [![Public testnet](https://img.shields.io/badge/public-testnet-981071.svg)](http://zygote.kowala.io)
 
 ## kCoin
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-[![Gitter chat](https://badges.gitter.im/kowala/kcoin.png)](https://gitter.im/kowala-tech/kcoin) [![Build Status](http://ci.kowala.io/api/badges/kowala-tech/kcoin/status.svg)](http://ci.kowala.io/kowala-tech/kcoin) [![Public testnet](https://img.shields.io/badge/public-testnet-981071.svg)](http://testnet.kowala.io)
+[![Build Status](http://ci.kowala.io/api/badges/kowala-tech/kcoin/status.svg)](http://ci.kowala.io/kowala-tech/kcoin) [![Public testnet](https://img.shields.io/badge/public-testnet-981071.svg)](http://testnet.kowala.io)
 
 ## kCoin
 
-Official implementation of the Kowala protocol based on the [go-ethereum client](https://github.com/ethereum/go-ethereum/). The **`kcoin`** client is the main client for the Kowala network and it's capable of running a full node - the client offers a gateway to the Kowala network to other processes. To learn more about Kowala please visit the [official documentation](http://docs.kowala.tech/).
+Official implementation of the Kowala protocol based on the [go-ethereum client](https://github.com/ethereum/go-ethereum/). The **`kcoin`** client is the main client for the Kowala network and it's capable of running a full node - the client offers a gateway to the Kowala network to other processes. To learn more about the project please visit the [official documentation](http://docs.kowala.tech/).
 
 ## Getting Started
 
-- [Join the public testnet](http://docs.kowala.tech/getting-started/testnet/)
+[Join the public Zygote testnet](http://zygote.kowala.io)
 
 ## Core Contributors
 
@@ -14,4 +14,4 @@ Official implementation of the Kowala protocol based on the [go-ethereum client]
 
 ## Contact us
 
-Feel free to email us at support@kowala.tech or talk to us on [Telegram](https://t.co/MpSK3z1aWw)/[Gitter](https://gitter.im/kowala-tech/kcoin).
+Feel free to email us at support@kowala.tech or talk to us on [Telegram](https://t.co/MpSK3z1aWw).


### PR DESCRIPTION
This removes outdated links and allows the public repo to be shared.


Closes #381
