### PR TITLE
Accept a `--genesis-path` arg into the runner to load a specific genesis

### DIFF
--- a/release/kcoin.sh
+++ b/release/kcoin.sh
@@ -4,6 +4,7 @@ set -e
 TESTNET=false;
 NEW_ACC=false;
 NEW_ACC_PASS="";
+GENESIS_PATH="";
 
 command="";
 
@@ -23,6 +24,9 @@ do
 	  "--new-account-password="*)
 		NEW_ACC_PASS="${opt#*=}"
 		;;
+	  "--genesis-path="*)
+		GENESIS_PATH="${opt#*=}"
+		;;
 	  *)
 		command="$command$opt " # make sure this passed to the binary
 		;;
@@ -32,8 +36,8 @@ done
 cd /kcoin
 
 case $TESTNET in
-	(true)  ./kcoin init --testnet;;
-	(false) ./kcoin init;;
+	(true)  ./kcoin init --testnet "$GENESIS_PATH";;
+	(false) ./kcoin init "$GENESIS_PATH";;
 esac
 
 case $NEW_ACC in


### PR DESCRIPTION
In the e2e tests we need to use generated genesis files and not the default ones. This PR adds a param for the docker runner to specify a genesis file for the init. That genesis file is mounted as a volume when we run the tests.