### PR TITLE
Updated hardcoded ipc reference

### DIFF
--- a/release/kcoin.sh
+++ b/release/kcoin.sh
@@ -48,7 +48,7 @@ case $NEW_ACC in
 		;;
 esac
 
-./control --ipc /root/.kcoin/kcoin.ipc &
+./control --ipc /root/.kcoin/kusd/kcoin.ipc &
 status=$?
 if [ $status -ne 0 ]; then
   echo "Failed to start control panel: $status"


### PR DESCRIPTION
There's a hardcoded IPC reference for the web control panel that's used in the Docker contain execution. It was throwing an error because the .ipc file has been moved. 

This hardcoded reference is acceptable (for now) because there's a Dockerfile for kUSD (as opposed to kCoin).