### PR TITLE
Generate bindings for the cross compile process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ devtools: abigen
 kcoin-cross: kcoin-cross-build kcoin-cross-compress kcoin-cross-rename
 	@echo "Full cross compilation done."
 
-kcoin-cross-build:
+kcoin-cross-build: bindings
 	cd client; build/env.sh go run build/ci.go xgo -- --go=$(GO) --targets=linux/amd64,linux/arm64,darwin/amd64,windows/amd64 -v ./cmd/kcoin
 	mv client/build/bin/kcoin-darwin-10.6-amd64 client/build/bin/kcoin-osx-10.6-amd64
 


### PR DESCRIPTION
The cross-compilation also needs the buildings generated