### PR TITLE
Refactor notifications dockerfiles

### DIFF
--- a/notifications/api.Dockerfile
+++ b/notifications/api.Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN cd notifications && dep ensure --vendor-only
 RUN go build -a -o app notifications/cmd/api/main.go
 
-FROM alpine:latest3.7
+FROM alpine:3.7
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/kowala-tech/kcoin/app .

--- a/notifications/api.Dockerfile
+++ b/notifications/api.Dockerfile
@@ -1,11 +1,10 @@
-FROM golang:1.9.2-alpine as builder
+FROM kowalatech/go:1.0.4 as builder
 WORKDIR /go/src/github.com/kowala-tech/kcoin
-RUN apk update; apk add --no-cache git curl alpine-sdk
 COPY . .
-RUN make dep && cd notifications && dep ensure --vendor-only
+RUN cd notifications && dep ensure --vendor-only
 RUN go build -a -o app notifications/cmd/api/main.go
 
-FROM alpine:latest  
+FROM alpine:latest3.7
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/kowala-tech/kcoin/app .

--- a/notifications/emailer.Dockerfile
+++ b/notifications/emailer.Dockerfile
@@ -1,11 +1,10 @@
-FROM golang:1.9.2-alpine as builder
+FROM kowalatech/go:1.0.4 as builder
 WORKDIR /go/src/github.com/kowala-tech/kcoin
-RUN apk update; apk add --no-cache git curl alpine-sdk
 COPY . .
-RUN make dep && cd notifications && dep ensure --vendor-only
+RUN cd notifications && dep ensure --vendor-only
 RUN go build -a -o app notifications/cmd/emailer/main.go
 
-FROM alpine:latest  
+FROM alpine:3.7
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/kowala-tech/kcoin/app .

--- a/notifications/transactions_db_synchronize.Dockerfile
+++ b/notifications/transactions_db_synchronize.Dockerfile
@@ -1,11 +1,10 @@
-FROM golang:1.9.2-alpine as builder
+FROM kowalatech/go:1.0.4 as builder
 WORKDIR /go/src/github.com/kowala-tech/kcoin
-RUN apk update; apk add --no-cache git curl alpine-sdk
 COPY . .
-RUN make dep && cd notifications && dep ensure --vendor-only
+RUN cd notifications && dep ensure --vendor-only
 RUN go build -a -o app notifications/cmd/transactions_persistence/main.go
 
-FROM alpine:latest  
+FROM alpine:3.7
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/kowala-tech/kcoin/app .

--- a/notifications/transactions_publisher.Dockerfile
+++ b/notifications/transactions_publisher.Dockerfile
@@ -1,11 +1,10 @@
-FROM golang:1.9.2-alpine as builder
+FROM kowalatech/go:1.0.4 as builder
 WORKDIR /go/src/github.com/kowala-tech/kcoin
-RUN apk update; apk add --no-cache git curl alpine-sdk
 COPY . .
-RUN make dep && cd notifications && dep ensure --vendor-only
+RUN cd notifications && dep ensure --vendor-only
 RUN go build -a -o app notifications/cmd/transactions_publisher/main.go
 
-FROM alpine:latest  
+FROM alpine:3.7  
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/kowala-tech/kcoin/app .


### PR DESCRIPTION
Notifications dockerfiles now use our custom go docker image to build the binary and alpine 3.7 for the release image.