### PR TITLE
Print out how to solve go-generate errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ docker_go_generate:
 .PHONY: assert_no_changes
 assert_no_changes:
 	git status
-	if ! git diff-index --quiet HEAD; then echo "There are uncommited go generate files."; exit 1; fi
+	@if ! git diff-index --quiet HEAD; then echo "There are uncommited go generate files.\nRun `make docker_go_generate` to regenerate all of them."; exit 1; fi
 
 .PHONY: notifications_dep
 notifications_dep: dep


### PR DESCRIPTION
If the go-generate check fails, it prints out what to run to solve it.