### PR TITLE
Put commit and tag binary releases in folders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,15 +136,17 @@ kcoin_cross_compress:
 kcoin_cross_rename:
 ifdef DRONE_TAG
 	cd client/build/bin && for f in kcoin-*; do \
+		mkdir -p "client/build/bin/tags/$(DRONE_TAG)";\
 		release=$$(echo $$f | awk '{ gsub("kcoin", "kcoin-stable"); print }');\
-		version=$$(echo $$f | awk '{ gsub("kcoin", "kcoin-$(DRONE_TAG)"); print }');\
+		version=$$(echo $$f | awk '{ gsub("kcoin", "tags/$(DRONE_TAG)/kcoin"); print }');\
 		cp $$f $$release;\
 		mv $$f $$version;\
 	done;
 else
 	cd client/build/bin && for f in kcoin-*; do \
+		mkdir -p "client/build/bin/commits/$(DRONE_COMMIT_SHA)";\
 		release=$$(echo $$f | awk '{ gsub("kcoin", "kcoin-unstable"); print }');\
-		version=$$(echo $$f | awk '{ gsub("kcoin", "kcoin-$(DRONE_COMMIT_SHA)"); print }');\
+		version=$$(echo $$f | awk '{ gsub("kcoin", "commits/$(DRONE_COMMIT_SHA)/kcoin"); print }');\
 		cp $$f $$release;\
 		mv $$f $$version;\
 	done;


### PR DESCRIPTION
For a cleaner S3 folder structure, puts commit and tag releases in folders.
The stable and unstable releases don't change, so all links pointing to them will still work.