### PR TITLE
Console minting tools

### DIFF
--- a/client/internal/web3ext/web3ext.go
+++ b/client/internal/web3ext/web3ext.go
@@ -463,8 +463,14 @@ web3._extend({
 		new web3._extend.Method({
 			name: 'mint',
 			call: 'mtoken_mint',
+			params: 3,
+			inputFormatter: [web3._extend.formatters.inputAddressFormatter, web3._extend.formatters.inputAddressFormatter, web3._extend.utils.fromDecimal]
+		}),
+		new web3._extend.Method({
+			name: 'confirm',
+			call: 'mtoken_confirm',
 			params: 2,
-			inputFormatter: [web3._extend.formatters.inputTransactionFormatter, null]
+			inputFormatter: [web3._extend.formatters.inputAddressFormatter, web3._extend.utils.fromDecimal]
 		})
 	],
 	properties: []

--- a/client/knode/api.go
+++ b/client/knode/api.go
@@ -180,12 +180,14 @@ type TransferArgs struct {
 type PublicTokenAPI struct {
 	accountMgr *accounts.Manager
 	consensus  consensus.Consensus
+	chainID    *big.Int
 }
 
-func NewPublicTokenAPI(accountMgr *accounts.Manager, c consensus.Consensus) *PublicTokenAPI {
+func NewPublicTokenAPI(accountMgr *accounts.Manager, c consensus.Consensus, chainID *big.Int) *PublicTokenAPI {
 	return &PublicTokenAPI{
 		accountMgr: accountMgr,
 		consensus:  c,
+		chainID:    chainID,
 	}
 }
 
@@ -194,7 +196,7 @@ func (api *PublicTokenAPI) GetBalance(target common.Address) (*big.Int, error) {
 }
 
 func (api *PublicTokenAPI) Transfer(args TransferArgs) (common.Hash, error) {
-	walletAccount, err := api.getWallet(args.From)
+	_, walletAccount, err := api.getWallet(args.From)
 	if err != nil {
 		return common.Hash{}, err
 	}
@@ -206,50 +208,56 @@ func (api *PublicTokenAPI) Transfer(args TransferArgs) (common.Hash, error) {
 	return api.consensus.Token().Transfer(walletAccount, *args.To, (*big.Int)(args.Value), args.Data, args.CustomFallback)
 }
 
-func (api *PublicTokenAPI) Mint(args TransferArgs, pass string, to common.Address, value *big.Int) (common.Hash, error) {
+func (api *PublicTokenAPI) Mint(from, to common.Address, value *hexutil.Big) (common.Hash, error) {
 	if value == nil {
 		return common.Hash{}, errors.New("a number of tokens should be specified")
 	}
 
-	walletAccount, err := api.getWallet(args.From)
+	account, walletAccount, err := api.getWallet(from)
 	if err != nil {
 		return common.Hash{}, err
 	}
 
-	account := accounts.Account{Address: args.From}
-	wallet, err := api.accountMgr.Find(account)
-	if err != nil {
-		return common.Hash{}, err
+	tOpts := &accounts.TransactOpts{
+		From: from,
+		Signer: func(signer types.Signer, address common.Address, tx *types.Transaction) (*types.Transaction, error) {
+			return walletAccount.SignTx(*account, tx, api.chainID)
+		},
 	}
 
-	transactOpts, err := wallet.NewKeyedTransactor(walletAccount.Account(), pass)
-	if err != nil {
-		return common.Hash{}, err
-	}
-
-	return api.consensus.Mint(toTransact(transactOpts, args), to, value)
+	return api.consensus.Mint(tOpts, to, value.ToInt())
 }
 
-func toTransact(txOpts *accounts.TransactOpts, args TransferArgs) *accounts.TransactOpts {
-	txOpts.Value = args.Value.ToInt()
-	return txOpts
+func (api *PublicTokenAPI) Confirm(from common.Address, transactionID *hexutil.Big) (common.Hash, error) {
+	account, walletAccount, err := api.getWallet(from)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	tOpts := &accounts.TransactOpts{
+		From: from,
+		Signer: func(signer types.Signer, address common.Address, tx *types.Transaction) (*types.Transaction, error) {
+			return walletAccount.SignTx(*account, tx, api.chainID)
+		},
+	}
+
+	return api.consensus.Confirm(tOpts, transactionID.ToInt())
 }
 
-func (api *PublicTokenAPI) getWallet(addr common.Address) (accounts.WalletAccount, error) {
+func (api *PublicTokenAPI) getWallet(addr common.Address) (*accounts.Account, accounts.WalletAccount, error) {
 	// Look up the wallet containing the requested signer
-	account := accounts.Account{Address: addr}
-
-	wallet, err := api.accountMgr.Find(account)
-	if err != nil {
-		return nil, err
+	for _, wallet := range api.accountMgr.Wallets() {
+		for _, account := range wallet.Accounts() {
+			if account.Address == addr {
+				walletAccount, err := accounts.NewWalletAccount(wallet, account)
+				if err != nil {
+					return nil, nil, err
+				}
+				return &account, walletAccount, nil
+			}
+		}
 	}
-
-	walletAccount, err := accounts.NewWalletAccount(wallet, account)
-	if err != nil {
-		return nil, err
-	}
-
-	return walletAccount, nil
+	return nil, nil, errors.New("account not found in any wallet")
 }
 
 // PrivateAdminAPI is the collection of Kowala full node-related APIs

--- a/client/knode/backend.go
+++ b/client/knode/backend.go
@@ -230,7 +230,7 @@ func (s *Kowala) APIs() []rpc.API {
 		}, {
 			Namespace: "mtoken",
 			Version:   "1.0",
-			Service:   NewPublicTokenAPI(s.accountManager, s.consensus),
+			Service:   NewPublicTokenAPI(s.accountManager, s.consensus, s.chainConfig.ChainID),
 			Public:    false,
 		}, {
 			Namespace: "eth",


### PR DESCRIPTION
This improves the console tools to mint.

Minting: `mtoken.mint(from, to, 10)`
Confirming: `mtoken.confirm(from, id)`

the minting returns the transaction ID sent to the contract to perform a minting. The transaction receipts will include logs with the minting ID, necessary for the confirmation.
The following function will help finding out the minting ID:
```
checkTransactionID = function(transaction) {
  var receipt = eth.getTransactionReceipt(transaction);
  if (receipt.status != "0x1") {
    console.error("The transaction is not in the blockchain");
    return -1;
  }
  for (var i = 0; i < receipt.logs.length; i++) {
    var log = receipt.logs[i];
    if (log.topics[0] == "0x4a504a94899432a9846e1aa406dceb1bcfd538bb839071d49d1e5e23f5be30ef") {
      return parseInt(log.topics[2]);
    }    
  }
  console.error("The operation wasn't successful. Ask a developer for more information.");
  return -1;
}
```

The first mtoken governor can mint tokens using:
```
transaction = mtoken.mint(eth.coinbase, to, 10); 
```

With that transaction hash, run the following until it returns a number different than -1:
```
checkTransactionID(transaction);
```

That number is the minting ID, necessary for the other governor, which will run something like:

```
mtoken.confirm(eth.coinbase, mintID)
```

Where `mintID` is the id returned by the `checkTransactionID`
