### PR TITLE
Fix windows binary build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ kcoin_cross: kcoin_cross_build kcoin_cross_compress kcoin_cross_rename
 kcoin_cross_build:
 	cd client; build/env.sh go run build/ci.go xgo -- --go=latest --targets=linux/amd64,linux/arm64,darwin/amd64,windows/amd64 -v ./cmd/kcoin
 	mv client/build/bin/kcoin-darwin-10.6-amd64 client/build/bin/kcoin-dawin-amd64
-	mv client/build/bin/kcoin-windows-4.0-amd64.exe client/build/bin/kcoin-windows-amd65.exe
+	mv client/build/bin/kcoin-windows-4.0-amd64.exe client/build/bin/kcoin-windows-amd64.exe
 
 .PHONY: kcoin_cross_compress
 kcoin_cross_compress:

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ kcoin_cross: kcoin_cross_build kcoin_cross_compress kcoin_cross_rename
 kcoin_cross_build:
 	cd client; build/env.sh go run build/ci.go xgo -- --go=latest --targets=linux/amd64,linux/arm64,darwin/amd64,windows/amd64 -v ./cmd/kcoin
 	mv client/build/bin/kcoin-darwin-10.6-amd64 client/build/bin/kcoin-dawin-amd64
-	mv client/build/bin/kcoin-windows-4-amd64 client/build/bin/kcoin-windows-amd64
+	mv client/build/bin/kcoin-windows-4.0-amd64.exe client/build/bin/kcoin-windows-amd65.exe
 
 .PHONY: kcoin_cross_compress
 kcoin_cross_compress:


### PR DESCRIPTION
The makefile had the wrong path for the windows binary, which was causing an error.