### PR TITLE
use bootnodesv5 flag and shorter discoveryV5 packet prefix

### DIFF
--- a/client/p2p/discv5/udp.go
+++ b/client/p2p/discv5/udp.go
@@ -124,8 +124,7 @@ type (
 )
 
 var (
-	//fixme: @jekamas use a shorter prefix. Breaking change!
-	versionPrefix     = []byte("temporary discovery v5")
+	versionPrefix     = []byte("kowalaV5")
 	versionPrefixSize = len(versionPrefix)
 	sigSize           = 520 / 8
 	headSize          = versionPrefixSize + sigSize // space of packet frame data

--- a/e2e/cluster/kcoin_node_builder.go
+++ b/e2e/cluster/kcoin_node_builder.go
@@ -39,7 +39,7 @@ func (builder *KcoinNodeBuilder) NodeSpec() *NodeSpec {
 		"--testnet",
 		"--gasprice", "1",
 		"--networkid", builder.networkId,
-		"--bootnodes", builder.bootnode,
+		"--bootnodesv5", builder.bootnode,
 		"--syncmode", builder.syncMode,
 		"--verbosity", strconv.Itoa(int(builder.logLevel)),
 	}


### PR DESCRIPTION
A short summary.

Important changes:
- [x] Something worth noting for reviewers.

Mandatory:
- [x] Added documentation.


Closes #
