### PR TITLE
Warn on stopping a non running validator

### DIFF
--- a/client/knode/validator/validator.go
+++ b/client/knode/validator/validator.go
@@ -172,6 +172,10 @@ func (val *validator) run() {
 }
 
 func (val *validator) Stop() error {
+	if !val.Running() {
+		return nil
+	}
+
 	if !val.Validating() {
 		return ErrCantStopNonStartedValidator
 	}


### PR DESCRIPTION
Only return error stop validator is running