### PR TITLE
Retool --dev mode for internal devnet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ go_generate: client/contracts/truffle/node_modules
 
 .PHONY: docker_go_generate
 docker_go_generate:
-	docker run --rm -v $(PWD):/go/src/github.com/kowala-tech/kcoin -w /go/src/github.com/kowala-tech/kcoin kowalatech/go:1.0.11 make go_generate
+	docker run --rm -v $(PWD):/go/src/github.com/kowala-tech/kcoin -w /go/src/github.com/kowala-tech/kcoin kowalatech/go:1.0.11 make install_tools go_generate
 
 .PHONY: assert_no_changes
 assert_no_changes:

--- a/client/cmd/kcoin/chaincmd.go
+++ b/client/cmd/kcoin/chaincmd.go
@@ -192,10 +192,11 @@ func initGenesis(ctx *cli.Context) error {
 //if --testnet is set, network key would be testnet, main otherwise.
 func extractNetworkKey(ctx *cli.Context) string {
 	isTestNet := ctx.GlobalBool(utils.TestnetFlag.Name)
+	isDevNet := ctx.GlobalBool(utils.DevModeFlag.Name)
 
 	var networkKey string
 
-	if isTestNet {
+	if isTestNet || isDevNet {
 		networkKey = genesisgen.TestNetwork
 	} else {
 		networkKey = genesisgen.MainNetwork

--- a/client/cmd/kcoin/chaincmd.go
+++ b/client/cmd/kcoin/chaincmd.go
@@ -34,6 +34,7 @@ var (
 			utils.DataDirFlag,
 			utils.LightModeFlag,
 			utils.TestnetFlag,
+			utils.DevModeFlag,
 			utils.CurrencyFlag,
 		},
 		Category: "BLOCKCHAIN COMMANDS",
@@ -191,11 +192,10 @@ func initGenesis(ctx *cli.Context) error {
 //if --testnet is set, network key would be testnet, main otherwise.
 func extractNetworkKey(ctx *cli.Context) string {
 	isTestNet := ctx.GlobalBool(utils.TestnetFlag.Name)
-	isDevNet := ctx.GlobalBool(utils.DevModeFlag.Name)
 
 	var networkKey string
 
-	if isTestNet || isDevNet {
+	if isTestNet {
 		networkKey = genesisgen.TestNetwork
 	} else {
 		networkKey = genesisgen.MainNetwork

--- a/client/cmd/kcoin/chaincmd.go
+++ b/client/cmd/kcoin/chaincmd.go
@@ -191,10 +191,11 @@ func initGenesis(ctx *cli.Context) error {
 //if --testnet is set, network key would be testnet, main otherwise.
 func extractNetworkKey(ctx *cli.Context) string {
 	isTestNet := ctx.GlobalBool(utils.TestnetFlag.Name)
+	isDevNet := ctx.GlobalBool(utils.DevModeFlag.Name)
 
 	var networkKey string
 
-	if isTestNet {
+	if isTestNet || isDevNet {
 		networkKey = genesisgen.TestNetwork
 	} else {
 		networkKey = genesisgen.MainNetwork

--- a/client/cmd/utils/flags.go
+++ b/client/cmd/utils/flags.go
@@ -1003,7 +1003,7 @@ func SetKowalaConfig(ctx *cli.Context, stack *node.Node, cfg *knode.Config) {
 		cfg.NetworkId = params.TestnetChainConfig.ChainID.Uint64()
 	case ctx.GlobalBool(DevModeFlag.Name):
 		// Use the main net network ID. This allows us to test the p2p under realistic conditions
-		cfg.NetworkId = 1
+		cfg.NetworkId = params.MainnetChainConfig.ChainID.Uint64()
 	}
 	// TODO(fjl): move trie cache generations into config
 	if gen := ctx.GlobalInt(TrieCacheGenFlag.Name); gen > 0 {

--- a/client/cmd/utils/flags.go
+++ b/client/cmd/utils/flags.go
@@ -114,11 +114,11 @@ var (
 	}
 	TestnetFlag = cli.BoolFlag{
 		Name:  "testnet",
-		Usage: "Ropsten network: pre-configured proof-of-work test network",
+		Usage: "Zygote network: pre-configured proof-of-stake test network",
 	}
 	DevModeFlag = cli.BoolFlag{
 		Name:  "dev",
-		Usage: "Developer mode: pre-configured private network with several debugging flags",
+		Usage: "Developer mode: pre-configured private test network",
 	}
 	IdentityFlag = cli.StringFlag{
 		Name:  "identity",
@@ -564,6 +564,8 @@ func setBootstrapNodes(ctx *cli.Context, cfg *p2p.Config) {
 		}
 	case ctx.GlobalBool(TestnetFlag.Name):
 		urls = params.TestnetBootnodes
+	case ctx.GlobalBool(DevModeFlag.Name):
+		urls = params.DevnetBootnodes
 	}
 
 	cfg.BootstrapNodes = make([]*discover.Node, 0, len(urls))
@@ -581,8 +583,12 @@ func setBootstrapNodes(ctx *cli.Context, cfg *p2p.Config) {
 // flags, reverting to pre-configured ones if none have been specified.
 func setBootstrapNodesV5(ctx *cli.Context, cfg *p2p.Config) {
 	urls := params.MainnetDiscoveryV5Bootnodes
-	if ctx.GlobalBool(TestnetFlag.Name) {
+
+	switch {
+	case ctx.GlobalBool(TestnetFlag.Name):
 		urls = params.TestnetDiscoveryV5Bootnodes
+	case ctx.GlobalBool(DevModeFlag.Name):
+		urls = params.DevnetDiscoveryV5Bootnodes
 	}
 
 	switch {
@@ -826,15 +832,6 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 		}
 		cfg.NetRestrict = list
 	}
-
-	if ctx.GlobalBool(DevModeFlag.Name) {
-		// --dev mode can't use p2p networking.
-		cfg.MaxPeers = 0
-		cfg.ListenAddr = ":0"
-		cfg.DiscoveryV5Addr = ":0"
-		cfg.NoDiscovery = true
-		cfg.DiscoveryV5 = false
-	}
 }
 
 // SetNodeConfig applies node-related command line flags to the config.
@@ -848,8 +845,6 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config, kowalaCfg *knode.Config) 
 	switch {
 	case ctx.GlobalIsSet(DataDirFlag.Name):
 		cfg.DataDir = ctx.GlobalString(DataDirFlag.Name)
-	case ctx.GlobalBool(DevModeFlag.Name):
-		cfg.DataDir = filepath.Join(os.TempDir(), "kowala_dev_mode")
 	}
 
 	if ctx.GlobalIsSet(KeyStoreDirFlag.Name) {
@@ -1007,10 +1002,8 @@ func SetKowalaConfig(ctx *cli.Context, stack *node.Node, cfg *knode.Config) {
 	case ctx.GlobalBool(TestnetFlag.Name):
 		cfg.NetworkId = params.TestnetChainConfig.ChainID.Uint64()
 	case ctx.GlobalBool(DevModeFlag.Name):
-		cfg.Genesis = core.DevGenesisBlock()
-		if !ctx.GlobalIsSet(GasPriceFlag.Name) {
-			cfg.GasPrice = new(big.Int)
-		}
+		// Use the main net network ID. This allows us to test the p2p under realistic conditions
+		cfg.NetworkId = 1
 	}
 	// TODO(fjl): move trie cache generations into config
 	if gen := ctx.GlobalInt(TrieCacheGenFlag.Name); gen > 0 {
@@ -1093,10 +1086,8 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node) kcoindb.Database {
 func MakeGenesis(ctx *cli.Context) *core.Genesis {
 	var genesis *core.Genesis
 	switch {
-	case ctx.GlobalBool(TestnetFlag.Name):
+	case ctx.GlobalBool(TestnetFlag.Name), ctx.GlobalBool(DevModeFlag.Name):
 		genesis = core.DefaultTestnetGenesisBlock()
-	case ctx.GlobalBool(DevModeFlag.Name):
-		genesis = core.DevGenesisBlock()
 	}
 	return genesis
 }

--- a/client/params/bootnodes.go
+++ b/client/params/bootnodes.go
@@ -8,6 +8,12 @@ var MainnetBootnodes = []string{}
 // test network.
 var TestnetBootnodes = []string{}
 
+var DevnetBootnodes = []string{}
+
+var DevnetDiscoveryV5Bootnodes = []string{
+	"enode://dd38c33eff2ba2fbf152bc698d86fa5baa18b30973e45700c48cdcc8555f2d437160731138960bc46f42b26e363ee5f8f1daa592cafa852669f91ef201ea569d@35.178.226.105:32233",
+}
+
 // TestnetDiscoveryV5Bootnodes are the enode URLs of the P2P bootstrap nodes for the
 // experimental RLPx v5 topic-discovery network.
 var TestnetDiscoveryV5Bootnodes = []string{

--- a/client/params/config.go
+++ b/client/params/config.go
@@ -33,7 +33,7 @@ var (
 	// means that all fields must be set at all times. This forces
 	// anyone adding flags to the config to also have to set these
 	// fields.
-	AllKonsensusProtocolChanges = &ChainConfig{big.NewInt(1337), new(KonsensusConfig)}
+	AllKonsensusProtocolChanges = &ChainConfig{big.NewInt(2), new(KonsensusConfig)}
 	TestChainConfig             = &ChainConfig{big.NewInt(1), new(KonsensusConfig)}
 	TestRules                   = TestChainConfig.Rules(new(big.Int))
 )

--- a/client/params/config_test.go
+++ b/client/params/config_test.go
@@ -23,7 +23,7 @@ func TestCheckCompatible(t *testing.T) {
 			new:    MainnetChainConfig,
 			wantErr: &ConfigCompatError{
 				What:         "Chain ID",
-				StoredConfig: big.NewInt(1337),
+				StoredConfig: big.NewInt(2),
 				NewConfig:    big.NewInt(1),
 				RewindTo:     0,
 			},

--- a/client/release/kcoin.sh
+++ b/client/release/kcoin.sh
@@ -2,7 +2,7 @@
 set -e
 
 DO_INIT=true;
-TESTNET=false;
+TESTNET="";
 NEW_ACC=false;
 NEW_ACC_PASS="";
 GENESIS_PATH="";
@@ -16,7 +16,11 @@ do
 
     case "$opt" in
 	  "--testnet")
-		TESTNET=true
+		TESTNET="--testnet"
+		command="$command$opt " # make sure this passed to the binary
+		;;
+	  "--dev")
+		TESTNET="--dev"
 		command="$command$opt " # make sure this passed to the binary
 		;;
 	  "version")
@@ -41,11 +45,8 @@ done
 cd /kcoin
 
 case $DO_INIT in
-	(true)
-		case $TESTNET in
-			(true)  ./kcoin init --testnet "$GENESIS_PATH";;
-			(false) ./kcoin init "$GENESIS_PATH";;
-		esac
+	(true) ./kcoin init $TESTNET "$GENESIS_PATH"
+		;;
 esac
 
 case $NEW_ACC in


### PR DESCRIPTION
Modified the  `--dev` flag to act a bit like `--testnet`. It uses the testnet genesis but network ID 1. This will be used for the internal devnet that's in progress. 

The testnet chain ID means that it works exactly like the existing testnet (only we can break it without annoying anyone) and the main network ID means that we can test the p2p against all the Ethereum traffic &mdash; a reasonable simulation of the main net environment.

### Network setup 

For anyone who's confused, the networks look like this:

|  Name  |    Netstats URL    | Genesis | Chain ID | Network ID |
|--------|--------------------|---------|----------|------------|
| Main   | kusd.kowala.tech   | Main    |        1 |          1 |
| Zygote | zygote.kowala.tech | Testnet |        2 |          2 |
| Dev    | devnet.kowala.io   | Testnet |        2 |          1 |

### Usage
You can run dev mode in the same way you normally would:

```
$ kcoin --dev init && kcoin --dev
```
or

```
$ docker run --rm -it kowalatech/kusd --dev
```
