### PR TITLE
Moved docs from PRs to proper location

### DIFF
--- a/docs/docs/advanced/minting-tokens.md
+++ b/docs/docs/advanced/minting-tokens.md
@@ -1,0 +1,125 @@
+# Minting mining tokens
+
+## Overview
+
+In the early stages of any real-currency network, or on a test net, it's
+necessary to generate and allocate mining tokens in order to validate on the
+network. 
+
+The sum of tokens for each network is 2^30, which is roughly one billion.  Only
+a few of these tokens are pre-minted (they're used by the genesis validator to
+start the network); the rest must be minted and allocated to token holders by a
+set of temporary governor accounts which are initially defined in the genesis
+block, and then controlled by vote of the governors themselves. Eventually all
+the tokens will be minted, and the governors can retire from their roles.
+
+Tokens are held by any valid address in the network. They can be held by humans
+via any kind of software, hardware or brain wallet key, and the can also be
+held by smart contracts.
+
+## Governance keys
+
+Each governor is represented by an account, or _governance key_, that is able
+to make transactions on the network. In the case of main nets, these are
+typically hardware keys that kept under very tight security.
+
+The governors are represented on the network as a multisig contract. There can
+be any number of governance keys, and the governors may choose between them the
+number of agreeing votes (called _confirmations_) required for any given
+transaction (a process sometimes called M of N). The minting of tokens is such
+a transaction, and it therefore requires a previously specified number of
+confirmations in order to take place.
+
+For example, a group of 5 governors might decide that they require 3 votes
+between them in order to issue some number of tokens to an account. In order to
+actually mint tokens, one governor would propose a transaction that mints X
+transactions to address Y.  Once two other governors confirm this initial
+proposition, the tokens would be automatically minted. If there are not enough
+votes, the tokens will never be minted.
+
+## Minting procedure
+
+The process consists of a series of data transactions made to a multisig contract
+that's embedded into the network genesis. Creating, signing and sending complex
+data transactions is rather difficult for most humans, so we're made some
+tooling in the console that makes things easier.
+
+The basic process is as described above: one governance key submits a
+transaction that will mint some tokens to an account. This initial submissions
+results in a _minting ID_: a number, which is an arbitrary reference to the
+suggested minting operation.  The remaining governance keys can confirm the
+transaction by referencing the minting ID &mdash; or ignore it if they don't want to
+confirm it.
+
+The operations that constitute this process take place in the Javascript console.
+In order to use them, you'll need to have a running node and access to your secure
+keys (which may be on USB devices).
+
+For the sake of simplicity, the examples given below assume 2 of 3 multisig setup.
+That is, one governor submits a transaction, and only one other governor has to
+confirm it.
+
+### Transaction submission
+
+#### Syntax
+
+ `mtoken.mint(governance_key_address, recipient_address, amount_of_tokens)`
+
+#### Example usage in the console 
+
+```
+> mtoken.mint(eth.coinbase, "0x1f1f1480f77b2565ae7f3a5580fd3da79b59b09b", 10); 
+```
+
+This would submit a transaction of 10 mtokens to the address ending `b09b`. The
+transaction will not be actioned until it's confirmed by another governance
+key.
+
+### Listing pending and complete transactions
+
+#### Syntax
+
+`mtoken.mintList()`
+
+#### Example usage in the console
+
+```
+> mtoken.mintList()
+```
+
+For which the output might be something like:
+
+```
+[{
+    amount: 42,
+    confirmed: false,
+    id: 0,
+    to: "0x1f1f1480f77b2565ae7f3a5580fd3da79b59b09b"
+}, {
+    amount: 44,
+    confirmed: true,
+    id: 1,
+    to: "0x1f1f1480f77b2565ae7f3a5580fd3da79b59b09b"
+}]
+```
+
+The `id` field is the minting ID, which will be needed in the confirmation
+step. Once a transaction is submitted, it will appear at the end of this list
+for verification. The `confirmed` field indicated whether or not another
+governance key has confirmed the transaction (and thus actioned it).
+
+### Confirming
+
+#### Syntax
+
+ `mtoken.confirm(governance_key_address, minting_id)`
+
+#### Example usage
+
+```
+> mtoken.confirm(eth.coinbase, 1)
+```
+
+This would confirm the transaction with minting ID `1`, and action it. In the
+example output above, it would issue 42 tokens to the address ending `b09b`.
+

--- a/docs/docs/advanced/official-networks.md
+++ b/docs/docs/advanced/official-networks.md
@@ -1,0 +1,19 @@
+# Official networks
+
+Kowala maintains three persistent networks, two of which are publically
+accessible.
+
+kUSD is the flagship kcoin currency, and our only main, or production, network.
+The testnet, branded as Zygote, is a production-ready environment that can be
+used for the development of applications, and it's where we test main net
+releases. The internal devnet is a highly unstable environment where we try out
+cutting-edge code and all sorts of other stuff that doesn't work.
+
+## Summary of networks
+
+|  Name  | Public |    Netstats URL    | Genesis | Chain ID | Network ID |
+|--------|--------|--------------------|---------|----------|------------|
+| kUSD   | Yes    | kusd.kowala.tech   | Main    |        1 |          1 |
+| Zygote | Yes    | zygote.kowala.tech | Testnet |        2 |          2 |
+| Dev    | No     | devnet.kowala.io   | Testnet |        2 |          1 |
+

--- a/docs/docs/getting-started/download.md
+++ b/docs/docs/getting-started/download.md
@@ -1,17 +1,50 @@
 # Downloads
 
-Binary distributions available for Linux, Mac OS X, Windows and more.
+## Binaries
 
-After downloading a binary release suitable for your system, please follow the [Connecting to the Kowala Network](/getting-started/testnet/#connecting-to-the-kowala-network) instructions.
+Binary distributions are available for Linux, Mac OS X and Windows (though we
+don't currently offer support for the Windows build). You'll need a binary, 
+as opposed to a Docker image, in order to use USB hardware wallets (including
+Ledger devices).
 
-## Stable versions
+After downloading a binary release suitable for your system, please follow the
+[Connecting to the Kowala Network](/getting-started/testnet/#connecting-to-the-kowala-network)
+instructions.
 
+### Supported, stable versions
 
- | Version           | File                                                                                                                              |   
- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------- | 
- | Windows           | [kcoin-stable-windows-4.0-amd64.exe.zip](https://s3.amazonaws.com/releases.kowala.tech/kcoin-stable-windows-4.0-amd64.exe.zip)    |
- | Mac OS X          | [kcoin-stable-osx-10.6-amd64.zip](https://s3.amazonaws.com/releases.kowala.tech/kcoin-stable-osx-10.6-amd64.zip)                  |
- | Linux 64bits      | [kcoin-stable-linux-amd64.zip](https://s3.amazonaws.com/releases.kowala.tech/kcoin-stable-linux-amd64.zip)                        |
- | Linux ARM 64bits  | [kcoin-stable-linux-arm64.zip](https://s3.amazonaws.com/releases.kowala.tech/kcoin-stable-linux-arm64.zip)                        |
+ | Operating system           | File                                                                                                                              |   
+ | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | 
+ | Mac OS X                   | [kcoin-stable-osx-10.6-amd64.zip](https://s3.amazonaws.com/releases.kowala.tech/kcoin-stable-osx-10.6-amd64.zip)                  |
+ | Linux 64bits               | [kcoin-stable-linux-amd64.zip](https://s3.amazonaws.com/releases.kowala.tech/kcoin-stable-linux-amd64.zip)                        |
+ | Linux ARM 64bits           | [kcoin-stable-linux-arm64.zip](https://s3.amazonaws.com/releases.kowala.tech/kcoin-stable-linux-arm64.zip)                        |
 
- <br><br>
+### Unsupported, stable versions
+
+ | Operating system           | File                                                                                                                              |   
+ | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | 
+ | Windows                    | [kcoin-stable-windows-4.0-amd64.exe.zip](https://s3.amazonaws.com/releases.kowala.tech/kcoin-stable-windows-4.0-amd64.exe.zip)    |
+
+## Docker image
+
+The easiest way to run the mining client is using Docker. The latest docker
+image is always available via
+[Dockerhub](https://hub.docker.com/r/kowalatech/kusd/). You can get the kUSD
+version by running 
+
+``` docker pull kowalatech/kusd ```
+
+in a terminal.
+
+### Dockerhub tags
+
+There are two main tags:
+
+| Tag name  |                      Purpose                      |
+|-----------|---------------------------------------------------|
+| `:latest` | The most up to date, stable version of the client |
+| `:dev`    | Cutting-edge development version of client.       |
+
+There are also granular tags for each verision. See the [full
+list](https://hub.docker.com/r/kowalatech/kusd/tags/).
+

--- a/docs/docs/getting-started/testnet.md
+++ b/docs/docs/getting-started/testnet.md
@@ -2,7 +2,7 @@
 
 This section will help you get started with the latest [test network](http://zygote.kowala.io/).
 
-The [Kowala Testnet](http://testnet.kowala.io/) is the perfect place for testing the Kowala Protocol, kCoins and mTokens without the fear of making a mistake and losing real money. You can spin up your own node and connect to the network, see how the network is performing using the [networks stats dashboard](http://testnet.kowala.io/stats/), and get free kUSD to play with using the [Kowala's faucet](http://faucet.testnet.kowala.io/).
+The [Kowala Testnet](http://zygote.kowala.tech/) is the perfect place for testing the Kowala Protocol, kCoins and mTokens without the fear of making a mistake and losing real money. You can spin up your own node and connect to the network, see how the network is performing using the [networks stats dashboard](http://zygote.kowala.tech/stats/), and get free kUSD to play with using the [Kowala's faucet](http://faucet.zygote.kowala.tech).
 
 ## Requirements
 
@@ -55,7 +55,7 @@ The console will output your public address. For example:
 "0xe2ac86cbae1bbbb47d157516d334e70859a1be45"
 ```
 
-You can use that address in the [Coin Faucet](<(http://faucet.testnet.kowala.io/)>) to acquire some free money. The Coin Faucet will send you money (the operation should take ~ 1 second), and you can check your balance with:
+You can use that address in the [Coin Faucet](<(http://zygote.testnet.kowala.tech/)>) to acquire some free money. The Coin Faucet will send you money (the operation should take ~ 1 second), and you can check your balance with:
 
 ```
 > kcoin.getBalance(kcoin.coinbase)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -48,7 +48,9 @@ pages:
       - 'Transaction': 'advanced/types/tx.md'
       - 'Account': 'advanced/types/account.md'
     - Automatic client updates: 'advanced/automatic-client-updates.md'
+    - Official networks: 'advanced/official-networks.md'
     - Running local testnet: 'advanced/running-local-testnet.md'
+    - Minting mining tokens: 'advanced/minting-tokens.md'
   - Contributing:
     - 'Projects': 'contributing/projects.md'
   - About:


### PR DESCRIPTION
We had a bunch of documentation in PRs and issues. I've moved it to the docs directory, so it can appear on the docs website.