### PR TITLE
Re-added install_tools to docker_go_generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ go_generate: client/contracts/truffle/node_modules
 
 .PHONY: docker_go_generate
 docker_go_generate:
-	docker run --rm -v $(PWD):/go/src/github.com/kowala-tech/kcoin -w /go/src/github.com/kowala-tech/kcoin kowalatech/go:1.0.12 make go_generate
+	docker run --rm -v $(PWD):/go/src/github.com/kowala-tech/kcoin -w /go/src/github.com/kowala-tech/kcoin kowalatech/go:1.0.12 make install_tools go_generate
 
 .PHONY: assert_no_changes
 assert_no_changes:


### PR DESCRIPTION
This is to prevent locally-compiled binaries on non-OS X machines from being reused in the docker process.