### PR TITLE
Default attach to the right IPC

### DIFF
--- a/client/cmd/kcoin/consolecmd.go
+++ b/client/cmd/kcoin/consolecmd.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kowala-tech/kcoin/client/cmd/utils"
 	"github.com/kowala-tech/kcoin/client/console"
+	"github.com/kowala-tech/kcoin/client/knode"
 	"github.com/kowala-tech/kcoin/client/node"
 	"github.com/kowala-tech/kcoin/client/rpc"
 	"gopkg.in/urfave/cli.v1"
@@ -110,6 +111,7 @@ func remoteConsole(ctx *cli.Context) error {
 				path = filepath.Join(path, "testnet")
 			}
 		}
+		path = filepath.Join(path, knode.DefaultConfig.Currency)
 		endpoint = fmt.Sprintf("%s/kcoin.ipc", path)
 	}
 	client, err := dialRPC(endpoint)


### PR DESCRIPTION
Close #803

`kcoin attach` now uses the default IPC file.